### PR TITLE
Implement priority queue with min-heap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dijkstrajs",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A simple JavaScript implementation of Dijkstra's single-source shortest-paths algorithm.",
   "main": "dijkstra.js",
   "scripts": {


### PR DESCRIPTION
I adopted the priority queue implementation with a min-heap data structure for better performance. I write the code in ES5 for backward compatibility with the previous version and for being upgradable. 

The previous current version is using `queue.sort()` for insertion with complexity of `n*log(n)`. With min-heap, the complexity will be `log(n)`.